### PR TITLE
Update GitHub Actions Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,9 @@ version: 2
 
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/setup-dependencies"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"


### PR DESCRIPTION
# Pull Request

## Description

Update Dependabot configuration to monitor GitHub Actions dependencies in the `.github/actions/setup-dependencies` directory in addition to the root directory. This ensures that Dependabot will check for updates in both locations, maintaining security and functionality across all GitHub Actions used in the repository.