### PR TITLE
Add Python Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,19 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "30 7 * * *"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      python:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

Added a new Dependabot configuration for the `uv` package ecosystem. The configuration:

- Schedules updates daily at 7:30 AM London time using a cron job
- Targets the main branch
- Groups all Python dependencies together
- Only applies to version updates
- Limits updates to patch and minor versions

This will help keep our `uv` dependencies up-to-date automatically while avoiding potentially breaking major version changes.